### PR TITLE
feat: add sourceParams.gatherAll

### DIFF
--- a/denops/@ddc-sources/input.ts
+++ b/denops/@ddc-sources/input.ts
@@ -3,12 +3,13 @@ import {
   Context,
   DdcOptions,
   Item,
+  Params,
   SourceOptions,
 } from "https://deno.land/x/ddc_vim@v4.0.4/types.ts";
 import { GetCompletePositionArguments } from "https://deno.land/x/ddc_vim@v4.0.4/base/source.ts";
 import { Denops, fn } from "https://deno.land/x/ddc_vim@v4.0.4/deps.ts";
 
-type Params = Record<string, never>;
+type Params = { gatherAll: boolean };
 
 export class Source extends BaseSource<Params> {
   override async getCompletePosition(
@@ -29,6 +30,7 @@ export class Source extends BaseSource<Params> {
     context: Context;
     options: DdcOptions;
     sourceOptions: SourceOptions;
+    sourceParams: Params;
     completeStr: string;
   }): Promise<Item[]> {
     // Get completion type
@@ -46,7 +48,7 @@ export class Source extends BaseSource<Params> {
     try {
       results = await fn.getcompletion(
         args.denops,
-        args.context.input,
+        args.sourceParams.gatherAll ? "" : args.context.input,
         mode == "=" ? "expression" : completionType,
       ) as string[];
     } catch (_) {
@@ -82,6 +84,6 @@ export class Source extends BaseSource<Params> {
   }
 
   override params(): Params {
-    return {};
+    return { gatherAll: false };
   }
 }

--- a/doc/ddc-source-input.txt
+++ b/doc/ddc-source-input.txt
@@ -27,8 +27,20 @@ https://github.com/vim-denops/denops.vim
 
 Note: |getcmdcompltype()| support is needed.
 
-Note: If you need to get fuzzy matched items, you need to set 'wildoptions'
-option contain "fuzzy".
+Note: If you need to get fuzzy matched items, a quick solution is adding
+"fuzzy" to 'wildoptions'. However, this applies to the limited types of
+completion. For the full control, combine |ddc-source-input-param-gatherAll|
+with arbitrary matchers of |ddc-filters|.
+
+
+==============================================================================
+PARAMS                                               *ddc-source-input-params*
+
+                                            *ddc-source-input-param-gatherAll*
+gatherAll	(boolean)
+		Gather all candidates regardless of the current input. Useful
+		when combining with matchers of |ddc-filters| implementing
+		non-forward-matching algorithms (e.g., fuzzy matching).
 
 
 ==============================================================================


### PR DESCRIPTION
Current document introduces `set wildoptions+=fuzzy`, but this applies to the limited types (e.g., commandline) and not others (e.g., file).

To get full control, this PR adds the `gatherAll` parameter.
In this way, users can apply any matching algorithm based on ddc-filter.

When this PR is approved, I will add the same parameter to `ddc-source-cmdline`.

